### PR TITLE
Add experiences widget information

### DIFF
--- a/en/homepage-configuration.md
+++ b/en/homepage-configuration.md
@@ -27,6 +27,7 @@ Eureka currently provides these widgets:
 -	**about**：A widget that displays information about the website author.
 -	**vintage**：The classic Eureka homepage component.
 -	**blank**：Completely customizable widget.
+-	**experiences**: Displays cards containing information such as position/title, organization, some dates, location, title, and a writeup.
 
 The content of the homepage is defined by the files in the `content/homepage` folder, and each widget corresponds to a file.
 
@@ -119,6 +120,65 @@ The image on the left side of the vintage widget. For the setting method, please
 **imgRight(string)**
 
 The picture on the right side of the vintage widget. For the setting method, please refer to [Image Loading](../content-management/#image-loading).
+
+### Experiences Widget Configuration
+
+The experiences widget is composed of multiple cards where each card displays a title, an organization (with a hyperlinked url), some dates, a location, and a writeup. There can be as many cards as desired in the experiences widget with each card containing their relevant information.
+
+Example usages for the experiences widget include documenting employment history, education history, awards, projects, etc.
+
+All the relevant parameters are contained in experiences section of the front matter. Additional cards can be added by adding a dash with the relevant parameters (title, organization, dates, location, writeup).
+
+Example below of the structure of the configuration.
+
+```
+experiences:
+	- title:
+		organization:
+			name:
+			url:
+		dates:
+		location:
+		writeup:
+
+	- title:
+		...  (repeat as necessary to add new cards below)
+```
+
+**experiences.title(string)**
+Optional. This string is at the top of the card in bold and in larger font size relative to the rest of the card..
+Markdown formatting is enabled.
+
+**experiences.organization.name(string)**
+Optional. This string is shown beside the country string below the title in normal sized font.
+Markdown formatting is enabled.
+
+**experiences.organization.url(string)**
+Optional. This url string in this parameter is used as the destination when the organization string is clicked.
+
+**experiences.dates(string)**
+Optional. This string is shown below the title in normal sized font.
+Markdown formatting is enabled.
+
+**experiences.location(string)**
+Optional. This string is shown beside the organization name string below the title in normal sized font.
+Markdown formatting is enabled.
+
+**experiences.writeup(string)**
+Optional. This string is what is shown at the bottom of the card below all other parameters. Markdown formatting is enabled. 
+
+To allow line breaks and bullet points, a blank line is required between each seperate line. Example below.
+
+```
+    writeup: >
+      Donec scelerisque egestas augue at tempor. Fusce faucibus magna in.
+
+      - Suspendisse lacinia mauris a laoreet vehicula.
+
+      - Aenean tincidunt enim vitae ante blandit tempor.
+
+      - Nam tincidunt diam quis lorem rutrum ullamcorper.
+```
 
 ## Sorting Widgets
 

--- a/zh/homepage-configuration.md
+++ b/zh/homepage-configuration.md
@@ -27,6 +27,7 @@ Eureka目前提供的小组件有：
 -	**about**：显示网站作者信息的组件。
 -	**vintage**：经典的Eureka主页组件。
 -	**blank**：可彻底自定义的组件。
+-	**experiences**: 显示包含职位、工作单位、时间地点及简介等信息的职业经历。
 
 主页内容由`content/homepage`文件夹中的文件定义，每一个小组件对应一个文件。
 
@@ -84,7 +85,7 @@ hugo new -k widgets/blank content/zh/homepage/<your-name.html>
 
 背景图片固定方式，可选值为fixed，local和scroll。
 
-### 配置pages小组件
+### 配置Pages小组件
 
 pages小组件有部分特有属性，也可以快速地进行配置。
 
@@ -100,11 +101,11 @@ pages小组件有部分特有属性，也可以快速地进行配置。
 
 显示样式，可选值为card，plain和masonry。
 
-### 配置about小组件
+### 配置About小组件
 
 about小组件的属性名与作者页参数一致，可参考[作者页参数](../content-management#作者页参数)。
 
-### 配置vintage小组件
+### 配置Vintage小组件
 
 vintage小组件默认为两张图片和一句标语构成。你可以简单地自定义图片内容及标语内容。
 
@@ -119,6 +120,61 @@ vintage小组件左侧图片，设置方式可参考[加载图片](../content-ma
 **imgRight(string)**
 
 vintage小组件右侧图片，设置方式可参考[加载图片](../content-management/#加载图片)。
+
+### 配置Experiences小组件
+
+Experiences小组件由多个包含职位、工作单位、时间地点及简介等信息的职业经历卡片组成。
+
+可能的使用方式可以包括职业经历、教育经历、奖项、项目等。
+
+所有Experiences小组件的信息包含在Front Matter中。更多的职业经历可以通过在Front Matter列表中添加新的对象进行添加。
+
+示例结构如下所示：
+
+```
+experiences:
+	- title:
+		organization:
+			name:
+			url:
+		dates:
+		location:
+		writeup:
+
+	- title:
+		...  (同上)
+```
+
+**experiences.title(string)**
+可选。该字符串会显示在卡片最上方，可使用Markdown语法。
+
+**experiences.organization.name(string)**
+可选。该字符串会显示在工作地点旁吗，可使用Markdown语法。
+
+**experiences.organization.url(string)**
+可选。该值可作为工作单位的链接地址。
+
+**experiences.dates(string)**
+可选。工作时间，可使用Markdown语法。
+
+**experiences.location(string)**
+可选。工作地点，可使用Markdown语法。
+
+**experiences.writeup(string)**
+可选。该值为经历简述，可使用Markdown语法。
+
+如果需要在Front Matter中使用多行字符串，可参考如下示例：
+
+```
+    writeup: >
+      Donec scelerisque egestas augue at tempor. Fusce faucibus magna in.
+
+      - Suspendisse lacinia mauris a laoreet vehicula.
+
+      - Aenean tincidunt enim vitae ante blandit tempor.
+
+      - Nam tincidunt diam quis lorem rutrum ullamcorper.
+```
 
 ## 小组件排序
 


### PR DESCRIPTION
This PR adds the necessary documentation on the experiences widget recently added to the hugo eureka theme.
I didn't check how it looks on the website, but I used standard markdown and it should be fine.

Let me know how it sounds. Let me know if I need to change anything.